### PR TITLE
use "/Library/RubyMotion/bin/ruby" instead of "macruby" for flymake

### DIFF
--- a/motion-mode.el
+++ b/motion-mode.el
@@ -104,7 +104,7 @@
     (defconst flymake-motion-err-line-patterns
       '(("^\\(.*\.rb\\):\\([0-9]+\\): \\(.*\\)$" 1 2 nil 3)))
 
-    (defvar flymake-motion-executable "macruby"
+    (defvar flymake-motion-executable "/Library/RubyMotion/bin/ruby"
       "The macruby executable to use for syntax checking.")
 
     ;; Invoke rubymotion with '-c' to get syntax checking


### PR DESCRIPTION
flymake で使用するものを macruby から /Library/RubyMotion/bin/ruby へ変更しました。
macruby がインストールされていないと動かないのはもったいないなと思い修正いたしました。

/Library/RubyMotion/bin/ruby 自体は RubyMotion で LLVM の中間コードを生成する際に使用しています。
