### PR TITLE
fix 'invalid byte sequence in US-ASCII'

### DIFF
--- a/bin/code_converter.rb
+++ b/bin/code_converter.rb
@@ -2,6 +2,6 @@
 $:.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
 require 'motion/code_converter'
 
-code = $stdin.read
+code = $stdin.set_encoding("UTF-8").read
 cnv  = Motion::CodeConverter.new(code)
 puts cnv.result


### PR DESCRIPTION
変換しようとしたObjective-CのコードにUS-ASCII以外の文字列が含まれると
`gsub!': invalid byte sequence in US-ASCII
というエラーで落ちるのをUTF-8で書かれていると決め打ちして修正しました。
