### PR TITLE
remove search filter because RubyMotion's document doesn't support iOS7 and OSX

### DIFF
--- a/motion-mode.el
+++ b/motion-mode.el
@@ -183,7 +183,7 @@
   (interactive)
   (let ((keyword (thing-at-point 'word)))
     (princ keyword)
-    (shell-command (format "open dash://rubymotion:%s" keyword))))
+    (shell-command (format "open dash://%s" keyword))))
 
 ;;;###autoload
 (defun motion-convert-code-region (start end)


### PR DESCRIPTION
Dash app でドキュメントを参照する際に、RubyMotion のドキュメントのみを扱うようにしていた箇所を修正しました。
Apple から著作権について指摘されて、RubyMotion のドキュメントが最新の iOS SDK に追従していくのが難しい(あと OSX の API ドキュメントを含んでいない) ので、それならば RubyMotion ドキュメントのみを対象に検索しない方が良さそうに思います。
